### PR TITLE
Fixed food log previous button. Issue #64

### DIFF
--- a/client/src/views/FoodLog.vue
+++ b/client/src/views/FoodLog.vue
@@ -153,6 +153,8 @@ async function getFoodLogAndDisplayResults() {
       if (enteredTodaysFood) {
         displayCurrentFoodLog(currentFoodLogIndex.value);
         calcTotalNutrients();
+      } else {
+        currentFoodLogIndex.value = Object.keys(res.logs).length;
       }
     }
   } catch {


### PR DESCRIPTION
On the food log, you can click the previous button to view older food logs